### PR TITLE
Correction de l'import 'rxjs/operators' |  Fixed 'rxjs/operators' import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import 'whatwg-fetch';
-import { from, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { from, Observable ,map } from 'rxjs';
 import { RequestMapper } from './mappers/request.mapper';
 import { checkHttpStatus } from './operators/check-http-status.operator';
 import { HttpRequestConfigurations } from './types/http-configurations.enum';


### PR DESCRIPTION
J'ai modifié l'import de 'rxjs/operators' pour le faire pointer sur 'rxjs' car cela pose problème lors de build de projet.

I changed the import of 'rxjs/operators' to point to 'rxjs' because it causes problems during project build.

