### PR TITLE
icoco - support POST form body like Content-type: application/x-www-form-urlencoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A simple to use http client built on ES6 fetch and RxJS.
 
-Version 7.0.9 is the latest stable version.
+Version 8.0.0 is the latest stable version.
 
-**As of 7.0.7 the fetch polyfill dependency has been removed. This is to allow support for browsers and node. If you require a fetch polyfill then you must import it into your application yourself.**
+**As of version 8.0.0, support for non-JSON bodies has been added. This means that the request 'Content-Type' header no longer defaults to the value 'application/json', which means you will need to provide this header in the request config for each request with a JSON body or in a RequestInterceptor.**
 
 ### Installing RxJS-Http-Client
 
@@ -83,6 +83,9 @@ Example of basic usage is shown below:
                const request = {
                    body: {
                        some: 'data'
+                   }, 
+                   headers: {
+                       'Content-Type': 'application/json'
                    }
                }
                
@@ -118,6 +121,9 @@ Example of basic usage is shown below:
             const request = {
                 body: {
                     some: 'data'
+                },
+                headers: {
+                    'Content-Type': 'application/json'
                 }
             }
             
@@ -153,6 +159,9 @@ Example of basic usage is shown below:
             const request = {
                 body: {
                     some: 'data'
+                },
+                headers: {
+                    'Content-Type': 'application/json'
                 }
             }
             
@@ -188,6 +197,9 @@ Example of basic usage is shown below:
             const request = {
                 body: {
                     some: 'data'
+                },
+                headers: {
+                    'Content-Type': 'application/json'
                 }
             }
             

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rxjs-http-client",
-  "version": "7.0.9",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rxjs-http-client",
-      "version": "7.0.9",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs-http-client",
-  "version": "7.0.9",
+  "version": "8.0.0",
   "description": "A simple to use http client built on ES6 fetch and RxJS",
   "main": "./rxjs-http-client.umd.js",
   "module": "./rxjs-http-client.es.js",

--- a/src/mappers/request.mapper.spec.ts
+++ b/src/mappers/request.mapper.spec.ts
@@ -3,37 +3,486 @@ import {HttpRequestConfigurations} from '../types/http-configurations.enum';
 import {HttpRequest} from '../types/http-request.class';
 
 describe('RequestMapper', () => {
-   describe('Given a request to map a request', () => {
-      it('Then the request is correctly mapped', () => {
-          const request = new HttpRequest('https://example.com', {
-              body: {
-                  'test-body': 'test-body-value'
-              },
-              headers: {
-                  'X-Authentication-Token': 'fake-auth-token'
-              },
-              cache: 'default',
-              mode: 'cors',
-              credentials: 'same-origin',
-              redirect: 'error',
-              referrer: 'test-referer',
-          });
+    describe('Given a request to map a GET request with no body', () => {
+        it('Then the request is correctly mapped with no body', () => {
+            const request = new HttpRequest('https://example.com', {
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
 
-          expect(RequestMapper.for(request, HttpRequestConfigurations.DELETE)).toEqual({
-              headers: {
-                  'Content-Type': 'application/json',
-                  'X-Authentication-Token': 'fake-auth-token'
-              },
-              referrer: 'test-referer',
-              cache: 'default',
-              mode: 'cors',
-              credentials: 'same-origin',
-              redirect: 'error',
-              method: 'DELETE',
-              body: JSON.stringify({
-                  'test-body': 'test-body-value'
-              })
-          });
-      });
-   });
+            expect(RequestMapper.for(request, HttpRequestConfigurations.GET)).toEqual({
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'GET',
+                body: null
+            });
+        });
+    });
+
+    describe('Given a request to map a GET request with a JSON body', () => {
+        it('Then the request is correctly mapped with no body', () => {
+            const request = new HttpRequest('https://example.com', {
+                body: {
+                    'test-body': 'test-body-value'
+                },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.GET)).toEqual({
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'GET',
+                body: null
+            });
+        });
+    });
+
+    describe('Given a request to map a GET request with a FormData body', () => {
+        it('Then the request is correctly mapped with no body', () => {
+            const formData = new FormData();
+            formData.append('name', 'Test name');
+
+            const request = new HttpRequest('https://example.com', {
+                body: formData,
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.GET)).toEqual({
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'GET',
+                body: null
+            });
+        });
+    });
+
+    describe('Given a request to map a POST request with no body', () => {
+        it('Then the request is correctly mapped with no body', () => {
+            const request = new HttpRequest('https://example.com', {
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.POST)).toEqual({
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'POST',
+                body: null
+            });
+        });
+    });
+
+    describe('Given a request to map a POST request with a JSON body', () => {
+        it('Then the request is correctly mapped with a JSON body', () => {
+            const request = new HttpRequest('https://example.com', {
+                body: {
+                    'test-body': 'test-body-value'
+                },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.POST)).toEqual({
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'POST',
+                body: JSON.stringify({
+                    'test-body': 'test-body-value'
+                })
+            });
+        });
+    });
+
+    describe('Given a request to map a POST request with a FormData body', () => {
+        it('Then the request is correctly mapped with a FormData body', () => {
+            const formData = new FormData();
+            formData.append('name', 'Test name');
+
+            const request = new HttpRequest('https://example.com', {
+                body: formData,
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.POST)).toEqual({
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'POST',
+                body: formData
+            });
+        });
+    });
+
+    describe('Given a request to map a PUT request with no body', () => {
+        it('Then the request is correctly mapped with no body', () => {
+            const request = new HttpRequest('https://example.com', {
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.PUT)).toEqual({
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'PUT',
+                body: null
+            });
+        });
+    });
+
+    describe('Given a request to map a PUT request with a JSON body', () => {
+        it('Then the request is correctly mapped with a JSON body', () => {
+            const request = new HttpRequest('https://example.com', {
+                body: {
+                    'test-body': 'test-body-value'
+                },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.PUT)).toEqual({
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'PUT',
+                body: JSON.stringify({
+                    'test-body': 'test-body-value'
+                })
+            });
+        });
+    });
+
+    describe('Given a request to map a PUT request with a FormData body', () => {
+        it('Then the request is correctly mapped with a FormData body', () => {
+            const formData = new FormData();
+            formData.append('name', 'Test name');
+
+            const request = new HttpRequest('https://example.com', {
+                body: formData,
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.PUT)).toEqual({
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'PUT',
+                body: formData
+            });
+        });
+    });
+
+    describe('Given a request to map a PATCH request with no body', () => {
+        it('Then the request is correctly mapped with no body', () => {
+            const request = new HttpRequest('https://example.com', {
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.PATCH)).toEqual({
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'PATCH',
+                body: null
+            });
+        });
+    });
+
+    describe('Given a request to map a PATCH request with a JSON body', () => {
+        it('Then the request is correctly mapped with a JSON body', () => {
+            const request = new HttpRequest('https://example.com', {
+                body: {
+                    'test-body': 'test-body-value'
+                },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.PATCH)).toEqual({
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'PATCH',
+                body: JSON.stringify({
+                    'test-body': 'test-body-value'
+                })
+            });
+        });
+    });
+
+    describe('Given a request to map a PATCH request with a FormData body', () => {
+        it('Then the request is correctly mapped with a FormData body', () => {
+            const formData = new FormData();
+            formData.append('name', 'Test name');
+
+            const request = new HttpRequest('https://example.com', {
+                body: formData,
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.PATCH)).toEqual({
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'PATCH',
+                body: formData
+            });
+        });
+    });
+
+    describe('Given a request to map a DELETE request with no body', () => {
+        it('Then the request is correctly mapped with no body', () => {
+            const request = new HttpRequest('https://example.com', {
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.DELETE)).toEqual({
+                headers: {
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'DELETE',
+                body: null
+            });
+        });
+    });
+
+    describe('Given a request to map a DELETE request with a JSON body', () => {
+        it('Then the request is correctly mapped with a JSON body', () => {
+            const request = new HttpRequest('https://example.com', {
+                body: {
+                    'test-body': 'test-body-value'
+                },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.DELETE)).toEqual({
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'DELETE',
+                body: JSON.stringify({
+                    'test-body': 'test-body-value'
+                })
+            });
+        });
+    });
+
+    describe('Given a request to map a DELETE request with a FormData body', () => {
+        it('Then the request is correctly mapped with a FormData body', () => {
+            const formData = new FormData();
+            formData.append('name', 'Test name');
+
+            const request = new HttpRequest('https://example.com', {
+                body: formData,
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                referrer: 'test-referer',
+            });
+
+            expect(RequestMapper.for(request, HttpRequestConfigurations.DELETE)).toEqual({
+                headers: {
+                    'Content-Type': 'multipart/form-data',
+                    'X-Authentication-Token': 'fake-auth-token'
+                },
+                referrer: 'test-referer',
+                cache: 'default',
+                mode: 'cors',
+                credentials: 'same-origin',
+                redirect: 'error',
+                method: 'DELETE',
+                body: formData
+            });
+        });
+    });
 });

--- a/src/mappers/request.mapper.ts
+++ b/src/mappers/request.mapper.ts
@@ -1,33 +1,9 @@
 import {HttpRequestConfigurations} from '../types/http-configurations.enum';
 import {HttpRequest} from '../types/http-request.class';
 
-const ContentTypeApplicationForm = 'application/x-www-form-urlencoded';
-const ContentTypeMultipartForm = 'multipart/form-data';
-
-function isFormContent(request: HttpRequest):boolean{
-    const headers = request.headers;
-    if ( !headers.hasOwnProperty('Content-Type')){
-        return false;
-    }
-    const contentType = headers['Content-Type'];
-    if (!contentType) {
-        return false;
-    }  
-    return contentType.includes(ContentTypeApplicationForm) || contentType.includes(ContentTypeMultipartForm);
-}
-
-function formatBody(request: HttpRequest,method: HttpRequestConfigurations):any{
-    
-    if ( isFormContent(request)){
-        return request.body;
-    } 
-    //continue  RESTFul call
-    const body = method !== HttpRequestConfigurations.GET ? JSON.stringify(request.body) : null;
-    return body;
-}
 export class RequestMapper {
     public static for(request: HttpRequest, method: HttpRequestConfigurations): RequestInit {
-        const result = {
+        return {
             cache: request.cache,
             mode: request.mode,
             credentials: request.credentials,
@@ -35,9 +11,19 @@ export class RequestMapper {
             redirect: request.redirect,
             referrer: request.referrer,
             method: method,
-           // body: method !== HttpRequestConfigurations.GET ? JSON.stringify(request.body) : null
-           body: formatBody(request,method)
+            body: this.formatBody(request, method)
         };
-        return result;
+    }
+
+    private static formatBody(request: HttpRequest, method: HttpRequestConfigurations): any {
+        if (method === HttpRequestConfigurations.GET || !request.body) {
+            return null;
+        }
+
+        if (request.body?.constructor === Object) {
+            return JSON.stringify(request.body);
+        }
+
+        return request.body;
     }
 }

--- a/src/mappers/request.mapper.ts
+++ b/src/mappers/request.mapper.ts
@@ -1,9 +1,33 @@
 import {HttpRequestConfigurations} from '../types/http-configurations.enum';
 import {HttpRequest} from '../types/http-request.class';
 
+const ContentTypeApplicationForm = 'application/x-www-form-urlencoded';
+const ContentTypeMultipartForm = 'multipart/form-data';
+
+function isFormContent(request: HttpRequest):boolean{
+    const headers = request.headers;
+    if ( !headers.hasOwnProperty('Content-Type')){
+        return false;
+    }
+    const contentType = headers['Content-Type'];
+    if (!contentType) {
+        return false;
+    }  
+    return contentType.includes(ContentTypeApplicationForm) || contentType.includes(ContentTypeMultipartForm);
+}
+
+function formatBody(request: HttpRequest,method: HttpRequestConfigurations):any{
+    
+    if ( isFormContent(request)){
+        return request.body;
+    } 
+    //continue  RESTFul call
+    const body = method !== HttpRequestConfigurations.GET ? JSON.stringify(request.body) : null;
+    return body;
+}
 export class RequestMapper {
     public static for(request: HttpRequest, method: HttpRequestConfigurations): RequestInit {
-        return {
+        const result = {
             cache: request.cache,
             mode: request.mode,
             credentials: request.credentials,
@@ -11,7 +35,9 @@ export class RequestMapper {
             redirect: request.redirect,
             referrer: request.referrer,
             method: method,
-            body: method !== HttpRequestConfigurations.GET ? JSON.stringify(request.body) : null
+           // body: method !== HttpRequestConfigurations.GET ? JSON.stringify(request.body) : null
+           body: formatBody(request,method)
         };
+        return result;
     }
 }

--- a/src/rxjs-http-client.spec.ts
+++ b/src/rxjs-http-client.spec.ts
@@ -42,10 +42,7 @@ describe('RxJSHttpClient', () => {
                     .subscribe({
                         next: () => {
                             expect(global.fetch).toHaveBeenCalledWith(url, {
-                                headers: {
-                                    ...request.headers,
-                                    'Content-Type': 'application/json',
-                                },
+                                headers: request.headers,
                                 referrer: request.referrer,
                                 cache: request.cache,
                                 mode: request.mode,
@@ -396,10 +393,7 @@ describe('RxJSHttpClient', () => {
                     .subscribe({
                         next: () => {
                             expect(global.fetch).toHaveBeenCalledWith(url, {
-                                headers: {
-                                    ...request.headers,
-                                    'Content-Type': 'application/json',
-                                },
+                                headers: request.headers,
                                 referrer: request.referrer,
                                 cache: request.cache,
                                 mode: request.mode,
@@ -752,10 +746,7 @@ describe('RxJSHttpClient', () => {
                     .subscribe({
                         next: () => {
                             expect(global.fetch).toHaveBeenCalledWith(url, {
-                                headers: {
-                                    ...request.headers,
-                                    'Content-Type': 'application/json',
-                                },
+                                headers: request.headers,
                                 referrer: request.referrer,
                                 cache: request.cache,
                                 mode: request.mode,
@@ -1108,10 +1099,7 @@ describe('RxJSHttpClient', () => {
                     .subscribe({
                         next: () => {
                             expect(global.fetch).toHaveBeenCalledWith(url, {
-                                headers: {
-                                    ...request.headers,
-                                    'Content-Type': 'application/json',
-                                },
+                                headers: request.headers,
                                 referrer: request.referrer,
                                 cache: request.cache,
                                 mode: request.mode,
@@ -1464,10 +1452,7 @@ describe('RxJSHttpClient', () => {
                     .subscribe({
                         next: () => {
                             expect(global.fetch).toHaveBeenCalledWith(url, {
-                                headers: {
-                                    ...request.headers,
-                                    'Content-Type': 'application/json',
-                                },
+                                headers: request.headers,
                                 referrer: request.referrer,
                                 cache: request.cache,
                                 mode: request.mode,

--- a/src/types/http-request.class.ts
+++ b/src/types/http-request.class.ts
@@ -3,14 +3,13 @@ import {HttpRequestConfig} from './http-request-config.class';
 
 export class HttpRequest {
     public url: string;
+    public headers: { [headerName: string]: string };
     public mode: RequestMode;
     public cache: RequestCache;
     public credentials: RequestCredentials;
     public redirect: RequestRedirect;
     public referrer: string;
     public body: any;
-
-    private _headers: { [headerName: string]: string };
 
     constructor(url: string, config: Partial<HttpRequestConfig>) {
         this.url = new RegExp(urlRegex).test(url) ? url : `${window.location.origin}${url}`;
@@ -21,21 +20,6 @@ export class HttpRequest {
         this.redirect = config.redirect || undefined;
         this.referrer = config.referrer || undefined;
         this.body = config.body || undefined;
-    }
-
-    public get headers(): { [headerName: string]: string } {
-        return this._headers;
-    }
-
-    public set headers(headers: { [headerName: string]: string }) {
-        if (headers.hasOwnProperty('Content-Type')) {
-            this._headers = headers;
-        } else {
-            this._headers = {
-                'Content-Type': 'application/json',
-                ...headers
-            };
-        }
     }
 
     public clone(): HttpRequest {


### PR DESCRIPTION
> Content-Type: application/x-www-form-urlencoded
want make the lib not only work for RESTful protocol but also common HTTP request like form post action.
wish helpfully :-)

Original PR: https://github.com/Jack-Overflow/rxjs-http-client/pull/47

Improving tests for request mapper to cover JSON and non-JSON bodies in requests.